### PR TITLE
fix: resolve errcheck linting issues in cmd/security_test.go

### DIFF
--- a/cmd/security_test.go
+++ b/cmd/security_test.go
@@ -81,9 +81,11 @@ func TestScanBlueprints_WithValidBlueprints(t *testing.T) {
 	err := scanBlueprints(blueprintsDir, false, "console")
 
 	// Restore stdout and capture output
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 	output := buf.String()
 
 	// Should not error with valid blueprints
@@ -113,9 +115,11 @@ func TestScanBlueprints_WithNonExistentPath(t *testing.T) {
 	err := scanBlueprints(nonExistentPath, false, "console")
 
 	// Restore stdout and capture output
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 
 	// Should return an error for non-existent path
 	assert.Error(t, err)
@@ -139,9 +143,11 @@ func TestScanBlueprints_VerboseMode(t *testing.T) {
 	err = scanBlueprints(tmpDir, true, "console")
 
 	// Restore stdout and capture output
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 	output := buf.String()
 
 	// Should not error
@@ -168,9 +174,11 @@ func TestScanBlueprints_JSONOutput(t *testing.T) {
 	err = scanBlueprints(tmpDir, false, "json")
 
 	// Restore stdout and capture output
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 	output := buf.String()
 
 	// Should not error
@@ -199,9 +207,11 @@ type: web-api
 	err := scanConfig(configFile, false, "console")
 
 	// Restore stdout and capture output
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 	output := buf.String()
 
 	// Should not error with valid config
@@ -236,9 +246,11 @@ func TestScanConfig_VerboseMode(t *testing.T) {
 	err := scanConfig(configFile, true, "console")
 
 	// Restore stdout and capture output
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 	output := buf.String()
 
 	// Should not error
@@ -259,9 +271,11 @@ func TestOutputSecurityResults_NoViolations(t *testing.T) {
 	err := outputSecurityResults([]security.SecurityViolation{}, "console", false)
 
 	// Restore stdout and capture output
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 	output := buf.String()
 
 	// Should not error
@@ -293,9 +307,11 @@ func TestOutputSecurityResults_WithViolations(t *testing.T) {
 	err := outputSecurityResults(violations, "console", false)
 
 	// Restore stdout and capture output
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 	output := buf.String()
 
 	// Should not error
@@ -317,9 +333,11 @@ func TestOutputSecurityResults_JSONFormat(t *testing.T) {
 	err := outputSecurityResults([]security.SecurityViolation{}, "json", false)
 
 	// Restore stdout and capture output
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 	output := buf.String()
 
 	// Should not error
@@ -341,12 +359,14 @@ func TestScanBlueprintsCmd_Execution(t *testing.T) {
 		err := scanBlueprintsCmd.RunE(scanBlueprintsCmd, []string{})
 
 		// Restore stdout
-		w.Close()
+		closeErr := w.Close()
+		require.NoError(t, closeErr)
 		os.Stdout = oldStdout
 
 		// Read output
 		var buf bytes.Buffer
-		buf.ReadFrom(r)
+		_, readErr := buf.ReadFrom(r)
+		require.NoError(t, readErr)
 
 		// Should handle the execution (may error due to missing blueprints in test env)
 		// but shouldn't panic
@@ -369,12 +389,14 @@ func TestScanConfigCmd_Execution(t *testing.T) {
 		err := scanConfigCmd.RunE(scanConfigCmd, []string{configFile})
 
 		// Restore stdout
-		w.Close()
+		closeErr := w.Close()
+		require.NoError(t, closeErr)
 		os.Stdout = oldStdout
 
 		// Read output
 		var buf bytes.Buffer
-		buf.ReadFrom(r)
+		_, readErr := buf.ReadFrom(r)
+		require.NoError(t, readErr)
 
 		// Should not error with valid config file
 		assert.NoError(t, err)
@@ -430,9 +452,11 @@ func TestScanBlueprints_EdgeCases(t *testing.T) {
 
 	err := scanBlueprints(emptyDir, false, "console")
 
-	w.Close()
+	closeErr := w.Close()
+	require.NoError(t, closeErr)
 	os.Stdout = oldStdout
-	buf.ReadFrom(r)
+	_, readErr := buf.ReadFrom(r)
+	require.NoError(t, readErr)
 	output := buf.String()
 
 	// Should not error with empty directory


### PR DESCRIPTION
## Summary
This PR fixes all errcheck linting failures identified in the CI/CD pipeline by adding proper error checking for previously unchecked error return values in `cmd/security_test.go`.

## Changes Made
- ✅ Add error checking for `w.Close()` calls in all test functions (12 instances)
- ✅ Add error checking for `buf.ReadFrom(r)` calls in all test functions (12 instances)  
- ✅ Use `require.NoError()` to ensure tests fail explicitly on unexpected errors
- ✅ Maintain existing test functionality while following Go best practices

## Fixed Locations
- `TestScanBlueprints_WithValidBlueprints` (lines 84, 86)
- `TestScanBlueprints_WithNonExistentPath` (lines 116, 118)
- `TestScanBlueprints_VerboseMode` (lines 142, 144)
- `TestScanConfig_WithValidConfig` (lines 202, 204)
- `TestScanConfig_VerboseMode` (lines 239, 241)
- `TestOutputSecurityResults_NoViolations` (lines 262, 264)
- `TestOutputSecurityResults_WithViolations` (lines 296, 298)
- `TestOutputSecurityResults_JSONFormat` (lines 320, 322)
- `TestScanBlueprintsCmd_Execution` (lines 344, 349)
- `TestScanConfigCmd_Execution` (lines 372, 377)
- `TestScanBlueprints_EdgeCases` (lines 433, 435)

## Verification
- ✅ All errcheck linting issues resolved (verified with `golangci-lint run`)
- ✅ Test functionality preserved - all changes maintain existing test logic
- ✅ Error handling follows Go best practices using `require.NoError()`
- ✅ Minimal changes focused only on fixing linting issues

## Impact
This change ensures that any unexpected errors during test execution (like pipe failures or buffer read issues) will cause tests to fail explicitly rather than being silently ignored, improving test robustness.

## Testing
The changes have been verified to resolve all errcheck linting issues without breaking existing test functionality.

@claude Please review this PR for the linting fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)