### PR TITLE
fix: correct mock struct naming to follow Go conventions

### DIFF
--- a/blueprints/grpc-gateway/internal/services/auth_test.go.tmpl
+++ b/blueprints/grpc-gateway/internal/services/auth_test.go.tmpl
@@ -35,17 +35,17 @@ func newNullLogger() logger.Logger {
 	return &nullLogger{}
 }
 
-// MockUserRepository is a mock implementation of UserRepository
-type MockUserRepository struct {
+// mockUserRepository is a mock implementation of UserRepository
+type mockUserRepository struct {
 	mock.Mock
 }
 
-func (m *MockUserRepository) Create(ctx context.Context, user *repository.User) (*repository.User, error) {
+func (m *mockUserRepository) Create(ctx context.Context, user *repository.User) (*repository.User, error) {
 	args := m.Called(ctx, user)
 	return args.Get(0).(*repository.User), args.Error(1)
 }
 
-func (m *MockUserRepository) GetByID(ctx context.Context, id string) (*repository.User, error) {
+func (m *mockUserRepository) GetByID(ctx context.Context, id string) (*repository.User, error) {
 	args := m.Called(ctx, id)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -53,7 +53,7 @@ func (m *MockUserRepository) GetByID(ctx context.Context, id string) (*repositor
 	return args.Get(0).(*repository.User), args.Error(1)
 }
 
-func (m *MockUserRepository) GetByEmail(ctx context.Context, email string) (*repository.User, error) {
+func (m *mockUserRepository) GetByEmail(ctx context.Context, email string) (*repository.User, error) {
 	args := m.Called(ctx, email)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -61,17 +61,17 @@ func (m *MockUserRepository) GetByEmail(ctx context.Context, email string) (*rep
 	return args.Get(0).(*repository.User), args.Error(1)
 }
 
-func (m *MockUserRepository) Update(ctx context.Context, user *repository.User) (*repository.User, error) {
+func (m *mockUserRepository) Update(ctx context.Context, user *repository.User) (*repository.User, error) {
 	args := m.Called(ctx, user)
 	return args.Get(0).(*repository.User), args.Error(1)
 }
 
-func (m *MockUserRepository) Delete(ctx context.Context, id string) error {
+func (m *mockUserRepository) Delete(ctx context.Context, id string) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
-func (m *MockUserRepository) List(ctx context.Context, pageSize int, pageToken string) ([]*repository.User, string, int, error) {
+func (m *mockUserRepository) List(ctx context.Context, pageSize int, pageToken string) ([]*repository.User, string, int, error) {
 	args := m.Called(ctx, pageSize, pageToken)
 	return args.Get(0).([]*repository.User), args.String(1), args.Int(2), args.Error(3)
 }
@@ -89,7 +89,7 @@ func TestAuthService(t *testing.T) {
 	{{- end}}
 
 	t.Run("Login", func(t *testing.T) {
-		mockRepo := new(MockUserRepository)
+		mockRepo := new(mockUserRepository)
 		authService := NewAuthService(
 			mockRepo,
 			passwordService,
@@ -220,7 +220,7 @@ func TestAuthService(t *testing.T) {
 
 	{{- if eq .AuthType "jwt"}}
 	t.Run("ChangePassword", func(t *testing.T) {
-		mockRepo := new(MockUserRepository)
+		mockRepo := new(mockUserRepository)
 		authService := NewAuthService(mockRepo, passwordService, logger, authMiddleware)
 
 		testUserID := "user-123"
@@ -315,7 +315,7 @@ func TestAuthService(t *testing.T) {
 	{{- end}}
 
 	t.Run("VerifyUser", func(t *testing.T) {
-		mockRepo := new(MockUserRepository)
+		mockRepo := new(mockUserRepository)
 		authService := NewAuthService(
 			mockRepo,
 			passwordService,
@@ -394,7 +394,7 @@ func TestAuthServiceSecurityProperties(t *testing.T) {
 	{{- end}}
 
 	t.Run("login timing consistency", func(t *testing.T) {
-		mockRepo := new(MockUserRepository)
+		mockRepo := new(mockUserRepository)
 		authService := NewAuthService(
 			mockRepo,
 			passwordService,
@@ -454,7 +454,7 @@ func TestAuthServiceSecurityProperties(t *testing.T) {
 	})
 
 	t.Run("password rehashing", func(t *testing.T) {
-		mockRepo := new(MockUserRepository)
+		mockRepo := new(mockUserRepository)
 		authService := NewAuthService(
 			mockRepo,
 			passwordService,

--- a/blueprints/grpc-gateway/tests/unit/services_test.go.tmpl
+++ b/blueprints/grpc-gateway/tests/unit/services_test.go.tmpl
@@ -19,55 +19,55 @@ import (
 	userv1 "{{.ModulePath}}/gen/user/v1"
 )
 
-// MockUserRepository is a mock implementation of the user repository
-type MockUserRepository struct {
+// mockUserRepository is a mock implementation of the user repository
+type mockUserRepository struct {
 	mock.Mock
 }
 
-func (m *MockUserRepository) Create(ctx context.Context, user *models.User) error {
+func (m *mockUserRepository) Create(ctx context.Context, user *models.User) error {
 	args := m.Called(ctx, user)
 	return args.Error(0)
 }
 
-func (m *MockUserRepository) GetByID(ctx context.Context, id string) (*models.User, error) {
+func (m *mockUserRepository) GetByID(ctx context.Context, id string) (*models.User, error) {
 	args := m.Called(ctx, id)
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
-func (m *MockUserRepository) GetByEmail(ctx context.Context, email string) (*models.User, error) {
+func (m *mockUserRepository) GetByEmail(ctx context.Context, email string) (*models.User, error) {
 	args := m.Called(ctx, email)
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
-func (m *MockUserRepository) List(ctx context.Context, limit, offset int32) ([]*models.User, int64, error) {
+func (m *mockUserRepository) List(ctx context.Context, limit, offset int32) ([]*models.User, int64, error) {
 	args := m.Called(ctx, limit, offset)
 	return args.Get(0).([]*models.User), args.Get(1).(int64), args.Error(2)
 }
 
-func (m *MockUserRepository) Update(ctx context.Context, user *models.User) error {
+func (m *mockUserRepository) Update(ctx context.Context, user *models.User) error {
 	args := m.Called(ctx, user)
 	return args.Error(0)
 }
 
-func (m *MockUserRepository) Delete(ctx context.Context, id string) error {
+func (m *mockUserRepository) Delete(ctx context.Context, id string) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
-// MockLogger is a simple mock logger for testing
-type MockLogger struct{}
+// mockLogger is a simple mock logger for testing
+type mockLogger struct{}
 
-func (l *MockLogger) Debug(msg string, keysAndValues ...interface{}) {}
-func (l *MockLogger) Info(msg string, keysAndValues ...interface{})  {}
-func (l *MockLogger) Warn(msg string, keysAndValues ...interface{})  {}
-func (l *MockLogger) Error(msg string, keysAndValues ...interface{}) {}
-func (l *MockLogger) Fatal(msg string, keysAndValues ...interface{}) {}
-func (l *MockLogger) With(keysAndValues ...interface{}) logger.Logger {
+func (l *mockLogger) Debug(msg string, keysAndValues ...interface{}) {}
+func (l *mockLogger) Info(msg string, keysAndValues ...interface{})  {}
+func (l *mockLogger) Warn(msg string, keysAndValues ...interface{})  {}
+func (l *mockLogger) Error(msg string, keysAndValues ...interface{}) {}
+func (l *mockLogger) Fatal(msg string, keysAndValues ...interface{}) {}
+func (l *mockLogger) With(keysAndValues ...interface{}) logger.Logger {
 	return l
 }
 
 func TestHealthService(t *testing.T) {
-	log := &MockLogger{}
+	log := &mockLogger{}
 	healthService := services.NewHealthService(log)
 
 	t.Run("Check", func(t *testing.T) {
@@ -95,8 +95,8 @@ func TestHealthService(t *testing.T) {
 }
 
 func TestUserService(t *testing.T) {
-	log := &MockLogger{}
-	mockRepo := new(MockUserRepository)
+	log := &mockLogger{}
+	mockRepo := new(mockUserRepository)
 	
 	{{if ne .DatabaseDriver ""}}
 	userService := services.NewUserService(mockRepo, log)

--- a/blueprints/web-api-clean/tests/integration/api_test.go.tmpl
+++ b/blueprints/web-api-clean/tests/integration/api_test.go.tmpl
@@ -12,8 +12,8 @@ import (
 	"{{.ModulePath}}/internal/infrastructure/logger"
 )
 
-// MockHTTPContext implements ports.HTTPContext for testing
-type MockHTTPContext struct {
+// mockHTTPContext implements ports.HTTPContext for testing
+type mockHTTPContext struct {
 	statusCode int
 	body       interface{}
 	headers    map[string]string
@@ -22,8 +22,8 @@ type MockHTTPContext struct {
 	request    *http.Request
 }
 
-func NewMockHTTPContext() *MockHTTPContext {
-	return &MockHTTPContext{
+func newMockHTTPContext() *mockHTTPContext {
+	return &mockHTTPContext{
 		headers: make(map[string]string),
 		params:  make(map[string]string),
 		queries: make(map[string]string),
@@ -32,82 +32,82 @@ func NewMockHTTPContext() *MockHTTPContext {
 }
 
 // Request data methods
-func (m *MockHTTPContext) GetParam(key string) string {
+func (m *mockHTTPContext) GetParam(key string) string {
 	return m.params[key]
 }
 
-func (m *MockHTTPContext) GetQuery(key string) string {
+func (m *mockHTTPContext) GetQuery(key string) string {
 	return m.queries[key]
 }
 
-func (m *MockHTTPContext) GetHeader(key string) string {
+func (m *mockHTTPContext) GetHeader(key string) string {
 	return m.headers[key]
 }
 
-func (m *MockHTTPContext) BindJSON(obj interface{}) error {
+func (m *mockHTTPContext) BindJSON(obj interface{}) error {
 	return nil
 }
 
-func (m *MockHTTPContext) GetRequestContext() context.Context {
+func (m *mockHTTPContext) GetRequestContext() context.Context {
 	return context.Background()
 }
 
-func (m *MockHTTPContext) GetMethod() string {
+func (m *mockHTTPContext) GetMethod() string {
 	return m.request.Method
 }
 
-func (m *MockHTTPContext) GetRequest() *http.Request {
+func (m *mockHTTPContext) GetRequest() *http.Request {
 	return m.request
 }
 
 // Response methods
-func (m *MockHTTPContext) JSON(code int, obj interface{}) {
+func (m *mockHTTPContext) JSON(code int, obj interface{}) {
 	m.statusCode = code
 	m.body = obj
 }
 
-func (m *MockHTTPContext) String(code int, message string) {
+func (m *mockHTTPContext) String(code int, message string) {
 	m.statusCode = code
 	m.body = message
 }
 
-func (m *MockHTTPContext) NoContent(code int) {
+func (m *mockHTTPContext) NoContent(code int) {
 	m.statusCode = code
 	m.body = nil
 }
 
-func (m *MockHTTPContext) SetHeader(key, value string) {
+func (m *mockHTTPContext) SetHeader(key, value string) {
 	m.headers[key] = value
 }
 
-func (m *MockHTTPContext) GetStatusCode() int {
+func (m *mockHTTPContext) GetStatusCode() int {
 	return m.statusCode
 }
 
 // Client info methods
-func (m *MockHTTPContext) ClientIP() string {
+func (m *mockHTTPContext) ClientIP() string {
 	return "127.0.0.1"
 }
 
-func (m *MockHTTPContext) GetClientIP() string {
+func (m *mockHTTPContext) GetClientIP() string {
 	return "127.0.0.1"
 }
 
 // Middleware support methods
-func (m *MockHTTPContext) Next() {
+func (m *mockHTTPContext) Next() {
 	// No-op for testing
 }
 
-func (m *MockHTTPContext) GetErrors() []string {
+func (m *mockHTTPContext) GetErrors() []string {
 	return []string{}
 }
 
 // Context values for middleware data passing
-func (m *MockHTTPContext) Set(key string, value interface{}) {
+func (m *mockHTTPContext) Set(key string, value interface{}) {
 	// For testing, we can just ignore this or store in a map if needed
 }
 
-func (m *MockHTTPContext) Get(key string) (interface{}, bool) {
+func (m *mockHTTPContext) Get(key string) (interface{}, bool) {
 	// For testing, return nil/false unless specifically needed
 	return nil, false
 }
@@ -117,7 +117,7 @@ func TestHealthController(t *testing.T) {
 	healthController := controllers.NewHealthController()
 
 	// Create mock context
-	ctx := NewMockHTTPContext()
+	ctx := newMockHTTPContext()
 
 	// Test health endpoint
 	healthController.Health(ctx)
@@ -140,7 +140,7 @@ func TestReadinessController(t *testing.T) {
 	healthController := controllers.NewHealthController()
 
 	// Create mock context
-	ctx := NewMockHTTPContext()
+	ctx := newMockHTTPContext()
 
 	// Test readiness endpoint
 	healthController.Readiness(ctx)
@@ -160,7 +160,7 @@ func TestLivenessController(t *testing.T) {
 	healthController := controllers.NewHealthController()
 
 	// Create mock context
-	ctx := NewMockHTTPContext()
+	ctx := newMockHTTPContext()
 
 	// Test liveness endpoint
 	healthController.Liveness(ctx)

--- a/blueprints/web-api-clean/tests/mocks/mock_email_service.go.tmpl
+++ b/blueprints/web-api-clean/tests/mocks/mock_email_service.go.tmpl
@@ -8,32 +8,32 @@ import (
 	{{end}}
 )
 
-// MockEmailService is a mock implementation of ports.EmailService
-type MockEmailService struct {
+// mockEmailService is a mock implementation of ports.EmailService
+type mockEmailService struct {
 	mock.Mock
 }
 
 {{if ne .DatabaseDriver ""}}
 // SendWelcomeEmail provides a mock function with given fields: ctx, user
-func (m *MockEmailService) SendWelcomeEmail(ctx context.Context, user *entities.User) error {
+func (m *mockEmailService) SendWelcomeEmail(ctx context.Context, user *entities.User) error {
 	args := m.Called(ctx, user)
 	return args.Error(0)
 }
 
 // SendPasswordResetEmail provides a mock function with given fields: ctx, user, token
-func (m *MockEmailService) SendPasswordResetEmail(ctx context.Context, user *entities.User, token string) error {
+func (m *mockEmailService) SendPasswordResetEmail(ctx context.Context, user *entities.User, token string) error {
 	args := m.Called(ctx, user, token)
 	return args.Error(0)
 }
 
 // SendEmailVerification provides a mock function with given fields: ctx, user, token
-func (m *MockEmailService) SendEmailVerification(ctx context.Context, user *entities.User, token string) error {
+func (m *mockEmailService) SendEmailVerification(ctx context.Context, user *entities.User, token string) error {
 	args := m.Called(ctx, user, token)
 	return args.Error(0)
 }
 {{else}}
 // SendNotificationEmail provides a mock function with given fields: ctx, to, subject, body
-func (m *MockEmailService) SendNotificationEmail(ctx context.Context, to, subject, body string) error {
+func (m *mockEmailService) SendNotificationEmail(ctx context.Context, to, subject, body string) error {
 	args := m.Called(ctx, to, subject, body)
 	return args.Error(0)
 }

--- a/blueprints/web-api-clean/tests/mocks/mock_logger.go.tmpl
+++ b/blueprints/web-api-clean/tests/mocks/mock_logger.go.tmpl
@@ -5,38 +5,38 @@ import (
 	"{{.ModulePath}}/internal/domain/ports"
 )
 
-// MockLogger is a mock implementation of ports.Logger
-type MockLogger struct {
+// mockLogger is a mock implementation of ports.Logger
+type mockLogger struct {
 	mock.Mock
 }
 
 // Debug provides a mock function with given fields: msg, fields
-func (m *MockLogger) Debug(msg string, fields ...interface{}) {
+func (m *mockLogger) Debug(msg string, fields ...interface{}) {
 	m.Called(msg, fields)
 }
 
 // Info provides a mock function with given fields: msg, fields
-func (m *MockLogger) Info(msg string, fields ...interface{}) {
+func (m *mockLogger) Info(msg string, fields ...interface{}) {
 	m.Called(msg, fields)
 }
 
 // Warn provides a mock function with given fields: msg, fields
-func (m *MockLogger) Warn(msg string, fields ...interface{}) {
+func (m *mockLogger) Warn(msg string, fields ...interface{}) {
 	m.Called(msg, fields)
 }
 
 // Error provides a mock function with given fields: msg, fields
-func (m *MockLogger) Error(msg string, fields ...interface{}) {
+func (m *mockLogger) Error(msg string, fields ...interface{}) {
 	m.Called(msg, fields)
 }
 
 // Fatal provides a mock function with given fields: msg, fields
-func (m *MockLogger) Fatal(msg string, fields ...interface{}) {
+func (m *mockLogger) Fatal(msg string, fields ...interface{}) {
 	m.Called(msg, fields)
 }
 
 // With provides a mock function with given fields: fields
-func (m *MockLogger) With(fields ...interface{}) ports.Logger {
+func (m *mockLogger) With(fields ...interface{}) ports.Logger {
 	args := m.Called(fields)
 	if args.Get(0) == nil {
 		return m // Return self as a safe default
@@ -45,41 +45,41 @@ func (m *MockLogger) With(fields ...interface{}) ports.Logger {
 }
 
 // AssertDebugCalled asserts that Debug was called with the given message
-func (m *MockLogger) AssertDebugCalled(t mock.TestingT, msg string) bool {
+func (m *mockLogger) AssertDebugCalled(t mock.TestingT, msg string) bool {
 	return m.AssertCalled(t, "Debug", msg, mock.Anything)
 }
 
 // AssertInfoCalled asserts that Info was called with the given message
-func (m *MockLogger) AssertInfoCalled(t mock.TestingT, msg string) bool {
+func (m *mockLogger) AssertInfoCalled(t mock.TestingT, msg string) bool {
 	return m.AssertCalled(t, "Info", msg, mock.Anything)
 }
 
 // AssertWarnCalled asserts that Warn was called with the given message
-func (m *MockLogger) AssertWarnCalled(t mock.TestingT, msg string) bool {
+func (m *mockLogger) AssertWarnCalled(t mock.TestingT, msg string) bool {
 	return m.AssertCalled(t, "Warn", msg, mock.Anything)
 }
 
 // AssertErrorCalled asserts that Error was called with the given message
-func (m *MockLogger) AssertErrorCalled(t mock.TestingT, msg string) bool {
+func (m *mockLogger) AssertErrorCalled(t mock.TestingT, msg string) bool {
 	return m.AssertCalled(t, "Error", msg, mock.Anything)
 }
 
 // ExpectDebug sets up an expectation for Debug to be called
-func (m *MockLogger) ExpectDebug(msg string) *mock.Call {
+func (m *mockLogger) ExpectDebug(msg string) *mock.Call {
 	return m.On("Debug", msg, mock.Anything)
 }
 
 // ExpectInfo sets up an expectation for Info to be called
-func (m *MockLogger) ExpectInfo(msg string) *mock.Call {
+func (m *mockLogger) ExpectInfo(msg string) *mock.Call {
 	return m.On("Info", msg, mock.Anything)
 }
 
 // ExpectWarn sets up an expectation for Warn to be called
-func (m *MockLogger) ExpectWarn(msg string) *mock.Call {
+func (m *mockLogger) ExpectWarn(msg string) *mock.Call {
 	return m.On("Warn", msg, mock.Anything)
 }
 
 // ExpectError sets up an expectation for Error to be called
-func (m *MockLogger) ExpectError(msg string) *mock.Call {
+func (m *mockLogger) ExpectError(msg string) *mock.Call {
 	return m.On("Error", msg, mock.Anything)
 }

--- a/blueprints/web-api-clean/tests/mocks/mock_password_service.go.tmpl
+++ b/blueprints/web-api-clean/tests/mocks/mock_password_service.go.tmpl
@@ -4,19 +4,19 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// MockPasswordService is a mock implementation of ports.PasswordService
-type MockPasswordService struct {
+// mockPasswordService is a mock implementation of ports.PasswordService
+type mockPasswordService struct {
 	mock.Mock
 }
 
 // Hash provides a mock function with given fields: password
-func (m *MockPasswordService) Hash(password string) (string, error) {
+func (m *mockPasswordService) Hash(password string) (string, error) {
 	args := m.Called(password)
 	return args.String(0), args.Error(1)
 }
 
 // Verify provides a mock function with given fields: hashedPassword, password
-func (m *MockPasswordService) Verify(hashedPassword, password string) error {
+func (m *mockPasswordService) Verify(hashedPassword, password string) error {
 	args := m.Called(hashedPassword, password)
 	return args.Error(0)
 }

--- a/blueprints/web-api-clean/tests/mocks/mock_user_repository.go.tmpl
+++ b/blueprints/web-api-clean/tests/mocks/mock_user_repository.go.tmpl
@@ -7,19 +7,19 @@ import (
 	"{{.ModulePath}}/internal/domain/entities"
 )
 
-// MockUserRepository is a mock implementation of ports.UserRepository
-type MockUserRepository struct {
+// mockUserRepository is a mock implementation of ports.UserRepository
+type mockUserRepository struct {
 	mock.Mock
 }
 
 // Create provides a mock function with given fields: ctx, user
-func (m *MockUserRepository) Create(ctx context.Context, user *entities.User) error {
+func (m *mockUserRepository) Create(ctx context.Context, user *entities.User) error {
 	args := m.Called(ctx, user)
 	return args.Error(0)
 }
 
 // GetByID provides a mock function with given fields: ctx, id
-func (m *MockUserRepository) GetByID(ctx context.Context, id string) (*entities.User, error) {
+func (m *mockUserRepository) GetByID(ctx context.Context, id string) (*entities.User, error) {
 	args := m.Called(ctx, id)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -28,7 +28,7 @@ func (m *MockUserRepository) GetByID(ctx context.Context, id string) (*entities.
 }
 
 // GetByEmail provides a mock function with given fields: ctx, email
-func (m *MockUserRepository) GetByEmail(ctx context.Context, email string) (*entities.User, error) {
+func (m *mockUserRepository) GetByEmail(ctx context.Context, email string) (*entities.User, error) {
 	args := m.Called(ctx, email)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -37,7 +37,7 @@ func (m *MockUserRepository) GetByEmail(ctx context.Context, email string) (*ent
 }
 
 // GetByUsername provides a mock function with given fields: ctx, username
-func (m *MockUserRepository) GetByUsername(ctx context.Context, username string) (*entities.User, error) {
+func (m *mockUserRepository) GetByUsername(ctx context.Context, username string) (*entities.User, error) {
 	args := m.Called(ctx, username)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -46,19 +46,19 @@ func (m *MockUserRepository) GetByUsername(ctx context.Context, username string)
 }
 
 // Update provides a mock function with given fields: ctx, user
-func (m *MockUserRepository) Update(ctx context.Context, user *entities.User) error {
+func (m *mockUserRepository) Update(ctx context.Context, user *entities.User) error {
 	args := m.Called(ctx, user)
 	return args.Error(0)
 }
 
 // Delete provides a mock function with given fields: ctx, id
-func (m *MockUserRepository) Delete(ctx context.Context, id string) error {
+func (m *mockUserRepository) Delete(ctx context.Context, id string) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
 // List provides a mock function with given fields: ctx, offset, limit
-func (m *MockUserRepository) List(ctx context.Context, offset, limit int) ([]*entities.User, error) {
+func (m *mockUserRepository) List(ctx context.Context, offset, limit int) ([]*entities.User, error) {
 	args := m.Called(ctx, offset, limit)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -67,13 +67,13 @@ func (m *MockUserRepository) List(ctx context.Context, offset, limit int) ([]*en
 }
 
 // ExistsByEmail provides a mock function with given fields: ctx, email
-func (m *MockUserRepository) ExistsByEmail(ctx context.Context, email string) (bool, error) {
+func (m *mockUserRepository) ExistsByEmail(ctx context.Context, email string) (bool, error) {
 	args := m.Called(ctx, email)
 	return args.Bool(0), args.Error(1)
 }
 
 // ExistsByUsername provides a mock function with given fields: ctx, username
-func (m *MockUserRepository) ExistsByUsername(ctx context.Context, username string) (bool, error) {
+func (m *mockUserRepository) ExistsByUsername(ctx context.Context, username string) (bool, error) {
 	args := m.Called(ctx, username)
 	return args.Bool(0), args.Error(1)
 }

--- a/blueprints/web-api-clean/tests/unit/usecases_test.go.tmpl
+++ b/blueprints/web-api-clean/tests/unit/usecases_test.go.tmpl
@@ -12,10 +12,10 @@ import (
 )
 
 func TestUserUseCase_CreateUser(t *testing.T) {
-	mockRepo := new(mocks.MockUserRepository)
-	mockLogger := new(mocks.MockLogger)
-	mockPasswordService := new(mocks.MockPasswordService)
-	mockEmailService := new(mocks.MockEmailService)
+	mockRepo := new(mocks.mockUserRepository)
+	mockLogger := new(mocks.mockLogger)
+	mockPasswordService := new(mocks.mockPasswordService)
+	mockEmailService := new(mocks.mockEmailService)
 	useCase := usecases.NewUserUseCase(mockRepo, mockPasswordService, mockLogger, mockEmailService)
 
 	ctx := context.Background()

--- a/blueprints/web-api-standard/tests/unit/services_test.go.tmpl
+++ b/blueprints/web-api-standard/tests/unit/services_test.go.tmpl
@@ -16,17 +16,17 @@ import (
 	"{{.ModulePath}}/internal/services"
 )
 
-// MockUserRepository is a mock implementation of UserRepository
-type MockUserRepository struct {
+// mockUserRepository is a mock implementation of UserRepository
+type mockUserRepository struct {
 	mock.Mock
 }
 
-func (m *MockUserRepository) GetAll(limit, offset int) ([]models.User, error) {
+func (m *mockUserRepository) GetAll(limit, offset int) ([]models.User, error) {
 	args := m.Called(limit, offset)
 	return args.Get(0).([]models.User), args.Error(1)
 }
 
-func (m *MockUserRepository) GetByID(id uint) (*models.User, error) {
+func (m *mockUserRepository) GetByID(id uint) (*models.User, error) {
 	args := m.Called(id)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -34,7 +34,7 @@ func (m *MockUserRepository) GetByID(id uint) (*models.User, error) {
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
-func (m *MockUserRepository) GetByEmail(email string) (*models.User, error) {
+func (m *mockUserRepository) GetByEmail(email string) (*models.User, error) {
 	args := m.Called(email)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -42,7 +42,7 @@ func (m *MockUserRepository) GetByEmail(email string) (*models.User, error) {
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
-func (m *MockUserRepository) Create(user *models.User) error {
+func (m *mockUserRepository) Create(user *models.User) error {
 	args := m.Called(user)
 	// Simulate setting ID and timestamps
 	user.ID = 1
@@ -51,18 +51,18 @@ func (m *MockUserRepository) Create(user *models.User) error {
 	return args.Error(0)
 }
 
-func (m *MockUserRepository) Update(user *models.User) error {
+func (m *mockUserRepository) Update(user *models.User) error {
 	args := m.Called(user)
 	user.UpdatedAt = time.Now()
 	return args.Error(0)
 }
 
-func (m *MockUserRepository) Delete(id uint) error {
+func (m *mockUserRepository) Delete(id uint) error {
 	args := m.Called(id)
 	return args.Error(0)
 }
 
-func (m *MockUserRepository) Count() (int, error) {
+func (m *mockUserRepository) Count() (int, error) {
 	args := m.Called()
 	return args.Int(0), args.Error(1)
 }
@@ -70,12 +70,12 @@ func (m *MockUserRepository) Count() (int, error) {
 // UserServiceTestSuite tests the UserService
 type UserServiceTestSuite struct {
 	suite.Suite
-	mockRepo    *MockUserRepository
+	mockRepo    *mockUserRepository
 	userService services.UserService
 }
 
 func (suite *UserServiceTestSuite) SetupTest() {
-	suite.mockRepo = new(MockUserRepository)
+	suite.mockRepo = new(mockUserRepository)
 	suite.userService = services.NewUserService(suite.mockRepo)
 }
 
@@ -267,21 +267,21 @@ func (suite *UserServiceTestSuite) TestDeleteUser_NotFound() {
 // AuthServiceTestSuite tests the AuthService
 type AuthServiceTestSuite struct {
 	suite.Suite
-	mockUserService *MockUserService
+	mockUserService *mockUserService
 	authService     services.AuthService
 }
 
-// MockUserService is a mock implementation of UserService for auth tests
-type MockUserService struct {
+// mockUserService is a mock implementation of UserService for auth tests
+type mockUserService struct {
 	mock.Mock
 }
 
-func (m *MockUserService) GetUsers(page, limit int) ([]models.User, int, error) {
+func (m *mockUserService) GetUsers(page, limit int) ([]models.User, int, error) {
 	args := m.Called(page, limit)
 	return args.Get(0).([]models.User), args.Int(1), args.Error(2)
 }
 
-func (m *MockUserService) GetUserByID(id uint) (*models.User, error) {
+func (m *mockUserService) GetUserByID(id uint) (*models.User, error) {
 	args := m.Called(id)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -289,7 +289,7 @@ func (m *MockUserService) GetUserByID(id uint) (*models.User, error) {
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
-func (m *MockUserService) GetUserByEmail(email string) (*models.User, error) {
+func (m *mockUserService) GetUserByEmail(email string) (*models.User, error) {
 	args := m.Called(email)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -297,7 +297,7 @@ func (m *MockUserService) GetUserByEmail(email string) (*models.User, error) {
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
-func (m *MockUserService) CreateUser(req models.CreateUserRequest) (*models.User, error) {
+func (m *mockUserService) CreateUser(req models.CreateUserRequest) (*models.User, error) {
 	args := m.Called(req)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -305,7 +305,7 @@ func (m *MockUserService) CreateUser(req models.CreateUserRequest) (*models.User
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
-func (m *MockUserService) UpdateUser(id uint, req models.UpdateUserRequest) (*models.User, error) {
+func (m *mockUserService) UpdateUser(id uint, req models.UpdateUserRequest) (*models.User, error) {
 	args := m.Called(id, req)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -313,13 +313,13 @@ func (m *MockUserService) UpdateUser(id uint, req models.UpdateUserRequest) (*mo
 	return args.Get(0).(*models.User), args.Error(1)
 }
 
-func (m *MockUserService) DeleteUser(id uint) error {
+func (m *mockUserService) DeleteUser(id uint) error {
 	args := m.Called(id)
 	return args.Error(0)
 }
 
 func (suite *AuthServiceTestSuite) SetupTest() {
-	suite.mockUserService = new(MockUserService)
+	suite.mockUserService = new(mockUserService)
 	suite.authService = services.NewAuthService(suite.mockUserService, "test-secret", time.Hour)
 }
 


### PR DESCRIPTION
Fixes #68

## Summary
- Changed mock structs from PascalCase to camelCase (unexported types)
- Updated method receivers and instantiations across all blueprints
- Fixed web-api-clean, grpc-gateway, and web-api-standard blueprints
- Updated test file references to use new mock struct names
- Ensured compliance with Go naming conventions for unexported types

## Test plan
- [ ] Verify all blueprints still generate valid Go code
- [ ] Run `go build` on generated projects
- [ ] Run `go test` on generated test files
- [ ] Check that mock structs are properly unexported (camelCase)

🤖 Generated with [Claude Code](https://claude.ai/code)